### PR TITLE
add ibt playback speed control

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,24 @@ To incorporate **iRacingTelemetrySDK** into your projects, follow these steps:
     ```
 1. Create an instance of the TelemetryClient
 
-    The logger is required, but the IBT file is optional.
+    The TelemetryClient runs in one of two modes: Live or IBT file playback.
 
-    ```csharp
-    ILogger logger;
-    string ibtFile;
+	For live telemetry, you only need to provide a logger.
 
-    using var tc = TelemetryClient<TelemetryData>.Create(logger, ibtFile);
-    ```
+	```csharp
+	// live telemetry
+	using var tc = TelemetryClient<TelemetryData>.Create(logger);
+	```
 
-    If the IBT file is provided, telemetry data will be read from the file.<br/>
-    If no IBT file is provided, the SDK will connect to the running instance of IRacing.
+    For IBT playback, provide the path to the IBT file and an optional playback speed multiplier.  The speed multiplier will speed up or slow down the playback of the IBT file.<br/>
+    A speed of `1` will play the IBT file at the normal speed iRacing output the file (60 records/sec).  A speed of `20` will playback the file at 20x speed (20*60=1200 records/rec).<br/>
+    To play the file at maximum speed, use `int.MaxValue` as the multiplier value.
+
+	```csharp
+	// process the IBT file at 10x speed
+    var ibtOptions = new IBTOptions(@"C:\path\to\file.ibt", 10);
+	using var tc = TelemetryClient<TelemetryData>.Create(logger, ibtOptions);
+	```
 
 1. Add an event handler
 

--- a/SVappsLAB.iRacingTelemetrySDK/IBTPlayback/Governor.cs
+++ b/SVappsLAB.iRacingTelemetrySDK/IBTPlayback/Governor.cs
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C)2024 Scott Velez
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.using Microsoft.CodeAnalysis;
+**/
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace SVappsLAB.iRacingTelemetrySDK.IBTPlayback
+{
+    public record GovernorStats(long elapsedMs, int CurrentRecord, int TargetRecord, double OldDelay, double NewDelay);
+
+    public interface IPlaybackGovernor
+    {
+        public void StartPlayback();
+        public Task GovernSpeed(int recNum);
+        public GovernorStats GetStats();
+    }
+
+    public class SimpleGovernor : IPlaybackGovernor
+    {
+        const int STANDARD_HZ = 60;
+        const double STANDARD_MS_PER_RECORD = 1000d / STANDARD_HZ;
+        ILogger _logger;
+        int _playbackSpeedMultiplier;
+        double _adjustmentAmountInMs;
+        TimeSpan _delayTimeSpan;            // current delay amount
+        Stopwatch _stopwatch = new Stopwatch();
+        GovernorStats? _governorStats;
+
+        public SimpleGovernor(ILogger logger, int playbackSpeedMultiplier)
+        {
+            _logger = logger;
+            _playbackSpeedMultiplier = playbackSpeedMultiplier;
+            _adjustmentAmountInMs = STANDARD_MS_PER_RECORD / _playbackSpeedMultiplier / 5; // make delay +- changes in 5% increments
+        }
+
+        public GovernorStats GetStats() => _governorStats ?? throw new InvalidOperationException("No stats available.");
+
+        public void StartPlayback()
+        {
+            // at startup, the processing time seems to be about 1/4 of what we need to match the playback speed
+            // so we start with an artificially small delay that is 1/4 of the standard delay.
+            // the normal governor logic will align us with the correct target delay
+            _delayTimeSpan = TimeSpan.FromMilliseconds(STANDARD_MS_PER_RECORD / _playbackSpeedMultiplier) / 4;
+            _stopwatch.Start();
+        }
+
+        public Task GovernSpeed(int recNum)
+        {
+            if (!_stopwatch.IsRunning)
+                throw new InvalidOperationException("Playback has not been started.");
+
+            // short circuit if we are at max speed
+            if (_playbackSpeedMultiplier == int.MaxValue)
+            {
+                return Task.CompletedTask;
+            }
+
+            // every 30 records, (1/2 of the 60hz rate), recalculate the delay amount to account for drift
+            if (recNum != 0)
+            {
+                if (recNum % (STANDARD_HZ / 2) == 0)
+                {
+                    CalculateGoverningDelay(recNum);
+                }
+            }
+            // slow down processing to match the playback speed
+            return Task.Delay(_delayTimeSpan);
+        }
+
+        void CalculateGoverningDelay(int currentRecNum)
+        {
+            var elapsed = _stopwatch.ElapsedMilliseconds;
+            var targetRecNum = elapsed / (STANDARD_MS_PER_RECORD / _playbackSpeedMultiplier);
+
+            var oldDelay = _delayTimeSpan;
+            if (currentRecNum < targetRecNum)
+            {
+                if (_delayTimeSpan.TotalMilliseconds > _adjustmentAmountInMs)
+                    _delayTimeSpan -= TimeSpan.FromMilliseconds(_adjustmentAmountInMs);
+                else
+                    _delayTimeSpan = TimeSpan.Zero;
+            }
+            else
+            {
+                _delayTimeSpan += TimeSpan.FromMilliseconds(_adjustmentAmountInMs);
+            }
+
+            _governorStats = new GovernorStats(elapsed, currentRecNum, (int)targetRecNum, oldDelay.TotalMilliseconds, _delayTimeSpan.TotalMilliseconds);
+
+            _logger.LogDebug("calc governor. stats: {stats}", _governorStats);
+        }
+    }
+}
+
+

--- a/SVappsLAB.iRacingTelemetrySDK/SVappsLAB.iRacingTelemetrySDK.csproj
+++ b/SVappsLAB.iRacingTelemetrySDK/SVappsLAB.iRacingTelemetrySDK.csproj
@@ -29,7 +29,7 @@
 		<PackageTags>iRacing iRacingSDK irsdk IBT Telemetry SDK API</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>0.5.0</Version>
+		<Version>0.6.0</Version>
 		<Authors>Scott Velez</Authors>
 		<Company>SVappsLAB</Company>
 		<Copyright>Copyright (c) 2024 SVappsLAB</Copyright>

--- a/Samples/DumpVariables_DumpSessionInfo/Program.cs
+++ b/Samples/DumpVariables_DumpSessionInfo/Program.cs
@@ -36,16 +36,17 @@ namespace DumpVariables_DumpSessionInfo
             CancellationTokenSource cts = new CancellationTokenSource();
 
             // if you pass in a IBT filename, we'll use that, otherwise default to LIVE mode
-            var ibtFile = args.Length == 1 ? args[0] : null;
+            var ibtOptions = args.Length == 1 ? new IBTOptions(args[0]) : null;
+
             var logger = LoggerFactory
                     .Create(builder => builder
                     .AddConsole().AddSimpleConsole(o => o.SingleLine = true))
                     .CreateLogger("logger");
 
-            logger.LogInformation("pulling data from \'{source}\'", String.IsNullOrEmpty(ibtFile) ? "Live iRacing session" : "IBT file session");
+            logger.LogInformation("pulling data from \'{source}\'", ibtOptions != null ? "IBT file session" : "Live iRacing session");
 
             // create telemetry client  and subscribe
-            using var tc = TelemetryClient<TelemetryData>.Create(logger, ibtFile);
+            using var tc = TelemetryClient<TelemetryData>.Create(logger, ibtOptions);
             tc.OnConnectStateChanged += OnConnectStateChanged;
             tc.OnSessionInfoUpdate += OnSessionInfoUpdate;
 

--- a/Samples/LocationAndWarnings/Program.cs
+++ b/Samples/LocationAndWarnings/Program.cs
@@ -39,7 +39,7 @@ namespace LocationAndWarnings
             logger.LogInformation("processing data from \"{source}\"", String.IsNullOrEmpty(ibtFile) ? "online LIVE session" : "offline IBT file");
 
             // create telemetry client 
-            using var tc = TelemetryClient<TelemetryData>.Create(logger, ibtFile);
+            using var tc = TelemetryClient<TelemetryData>.Create(logger, new IBTOptions(ibtFile));
 
             // subscribe to telemetry updates
             tc.OnTelemetryUpdate += OnTelemetryUpdate;

--- a/Samples/SpeedRPMGear/Program.cs
+++ b/Samples/SpeedRPMGear/Program.cs
@@ -34,7 +34,7 @@ namespace SpeedRPMGear
                     .CreateLogger("logger");
 
             // create telemetry client 
-            using var tc = TelemetryClient<TelemetryData>.Create(logger, ibtFile);
+            using var tc = TelemetryClient<TelemetryData>.Create(logger, new IBTOptions(ibtFile));
 
             // subscribe to telemetry updates
             tc.OnTelemetryUpdate += OnTelemetryUpdate;

--- a/tests/IBT_Tests/Files/ReadFile.cs
+++ b/tests/IBT_Tests/Files/ReadFile.cs
@@ -27,10 +27,9 @@ namespace IBT_Tests.Files
         [Fact]
         public async Task ValidFileSucceeds()
         {
-
             var ibtFile = @"../../../data/race_test/lamborghinievogt3_spa up.ibt";
 
-            using var tc = TelemetryClient<TelemetryData>.Create(NullLogger.Instance, ibtFile);
+            using var tc = TelemetryClient<TelemetryData>.Create(NullLogger.Instance, new IBTOptions(ibtFile, int.MaxValue));
 
             var gotConnected = false;
             EventHandler<ConnectStateChangedEventArgs> handler = (_sender, e) =>
@@ -54,7 +53,7 @@ namespace IBT_Tests.Files
             Assert.Throws<FileNotFoundException>(() =>
             {
                 var ibtFile = @"no-such-file-name";
-                using var tc = TelemetryClient<TelemetryData>.Create(NullLogger.Instance, ibtFile);
+                using var tc = TelemetryClient<TelemetryData>.Create(NullLogger.Instance, new IBTOptions(ibtFile));
             });
         }
     }

--- a/tests/IBT_Tests/Fixture.cs
+++ b/tests/IBT_Tests/Fixture.cs
@@ -37,7 +37,7 @@ namespace IBT_Tests
         {
             var tcs = new TaskCompletionSource<bool>();
 
-            TelemetryClient = TelemetryClient<TelemetryData>.Create(NullLogger.Instance, _ibtPath);
+            TelemetryClient = TelemetryClient<TelemetryData>.Create(NullLogger.Instance, new IBTOptions(_ibtPath));
             TelemetryClient.OnSessionInfoUpdate += (object? sender, TelemetrySessionInfo si) =>
             {
                 TelemetrySessionInfo = si;

--- a/tests/UnitTests/IBTPlaybackGovernor.cs
+++ b/tests/UnitTests/IBTPlaybackGovernor.cs
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C)2024 Scott Velez
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.using Microsoft.CodeAnalysis;
+**/
+
+using System.Diagnostics;
+
+#if DEBUG
+using Microsoft.Extensions.Logging;
+using Serilog;
+#endif
+using SVappsLAB.iRacingTelemetrySDK.IBTPlayback;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace UnitTests
+{
+    public class LogFixture
+    {
+        public Microsoft.Extensions.Logging.ILogger Logger;
+        public LogFixture()
+        {
+#if DEBUG
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.File("governorStatsOutput.log")
+                .CreateLogger();
+
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddSerilog();
+            });
+
+            // create logger for test data
+            Logger = loggerFactory.CreateLogger("testLogger");
+#else
+            Logger = NullLogger.Instance;
+#endif
+        }
+    }
+    public class IBTPlaybackGovernor : IClassFixture<LogFixture>
+    {
+        Microsoft.Extensions.Logging.ILogger _logger;
+        public IBTPlaybackGovernor(LogFixture logFixture)
+        {
+            _logger = logFixture.Logger;
+        }
+        public static TheoryData<int, int> Data =>
+            new TheoryData<int, int>
+            {
+                    {  1, 5},
+                    { 10, 5},
+                    {1000, 5}
+            };
+
+        [Theory]
+        [Trait("Category", "Manual")]
+        [MemberData(nameof(Data))]
+        public async Task GovernorTests(int speedMultiplier, int secsOfDataToSimulate)
+        {
+            var recsToProcess = speedMultiplier * secsOfDataToSimulate * 60;  // 60 records per second
+
+            IPlaybackGovernor g = new SimpleGovernor(_logger, speedMultiplier);
+            g.StartPlayback();
+
+            var sw = new Stopwatch();
+            sw.Start();
+            for (int i = 0; i < recsToProcess; i++)
+            {
+                await g.GovernSpeed(i);
+            }
+            sw.Stop();
+
+            // differential
+            var elapsedSeconds = sw.ElapsedMilliseconds / 1000d;
+            var timeDiffInSeconds = Math.Abs(secsOfDataToSimulate - elapsedSeconds);
+
+            // we should be time accurate within 1 second at the end of the run
+            Assert.True(timeDiffInSeconds < 1);
+        }
+    }
+}
+
+
+

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -21,7 +21,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
add a multiplier speed option, to control the playback processing speed of the IBT file

A multiplier value of `1` plays the IBT file at the same speed iRacing recorded the data (60Hz).
A multiplier value of `25` plays the IBT file at 25x speed (25*60Hz=1500hz).
The default value, `int.MaxValue`,  plays the IBT file at maximum speed of  over 5000x (~300,000Hz)
