### PR TITLE
process sessionInfo in separate task

### DIFF
--- a/SVappsLAB.iRacingTelemetrySDK.CodeGen/CodeGen.cs
+++ b/SVappsLAB.iRacingTelemetrySDK.CodeGen/CodeGen.cs
@@ -49,7 +49,7 @@ namespace SVappsLAB.iRacingTelemetrySDK
                 } 
             }";
 
-        static iRacingData _iRacingData = new iRacingData();
+        static iRacingVars _iRacingData = new iRacingVars();
 
         public void Initialize(IncrementalGeneratorInitializationContext context)
         {

--- a/SVappsLAB.iRacingTelemetrySDK.CodeGen/iRacingData.cs
+++ b/SVappsLAB.iRacingTelemetrySDK.CodeGen/iRacingData.cs
@@ -26,7 +26,7 @@ using System.Collections.Generic;
 namespace SVappsLAB.iRacingTelemetrySDK
 {
     public record struct VarItem(string Name, int Type, int Length, bool IsTimeValue, string Desc, string Units);
-    public class iRacingData
+    public class iRacingVars
     {
         // a dictionary of all known variables from the iRacing SDK - both live sessions and offline ibt files
         // this data is used by the code generation to generate typed variables for your code.

--- a/SVappsLAB.iRacingTelemetrySDK/SVappsLAB.iRacingTelemetrySDK.csproj
+++ b/SVappsLAB.iRacingTelemetrySDK/SVappsLAB.iRacingTelemetrySDK.csproj
@@ -29,7 +29,7 @@
 		<PackageTags>iRacing iRacingSDK irsdk IBT Telemetry SDK API</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>0.6.5</Version>
+		<Version>0.6.7</Version>
 		<Authors>Scott Velez</Authors>
 		<Company>SVappsLAB</Company>
 		<Copyright>Copyright (c) 2024 SVappsLAB</Copyright>


### PR DESCRIPTION
in large sessions, there is so much yaml info to parse, it takes longer than 16.7ms to complete. this means we can sometimes miss a telemetry update.

the fix is to process the sessionInfo yaml parsing as a separate task so the telemetry updates can continue simultaneously at 60Hz rate, without missing any.

in testing, this resolved the issue and prevented any telemetry from being missed.