### PR TITLE
rename enums and flags

### DIFF
--- a/Samples/DumpVariables_DumpSessionInfo/DumpVariables_DumpSessionInfo.csproj
+++ b/Samples/DumpVariables_DumpSessionInfo/DumpVariables_DumpSessionInfo.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
-    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
+    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.0" />
   </ItemGroup>
 
 </Project>

--- a/Samples/LocationAndWarnings/LocationAndWarnings.csproj
+++ b/Samples/LocationAndWarnings/LocationAndWarnings.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
-    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
+    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.0" />
   </ItemGroup>
 
 </Project>

--- a/Samples/LocationAndWarnings/Program.cs
+++ b/Samples/LocationAndWarnings/Program.cs
@@ -1,12 +1,12 @@
 /**
  * Copyright (C)2024 Scott Velez
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -39,7 +39,7 @@ namespace LocationAndWarnings
 
             logger.LogInformation("processing data from \"{source}\"", ibtOptions == null ? "online LIVE session" : "offline IBT file");
 
-            // create telemetry client 
+            // create telemetry client
             using var tc = TelemetryClient<TelemetryData>.Create(logger, ibtOptions);
 
             // subscribe to telemetry updates
@@ -68,10 +68,10 @@ namespace LocationAndWarnings
                 logger.LogInformation(message);
             }
 
-            string GetEngineWarnings(irsdk_EngineWarnings engineWarnings)
+            string GetEngineWarnings(EngineWarnings engineWarnings)
             {
                 var warnings = new List<string>();
-                foreach (var flag in Enum.GetValues<irsdk_EngineWarnings>())
+                foreach (var flag in Enum.GetValues<EngineWarnings>())
                 {
                     // check if the flag is set
                     if (engineWarnings.HasFlag(flag))

--- a/Samples/SpeedRPMGear/SpeedRPMGear.csproj
+++ b/Samples/SpeedRPMGear/SpeedRPMGear.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
-    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
+    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.0" />
   </ItemGroup>
 
 </Project>

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/CodeGen.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/CodeGen.cs
@@ -168,17 +168,16 @@ namespace SVappsLAB.iRacingTelemetrySDK
         {
             var type = varName switch
             {
-                // specific enums
-                "CarIdxTrackSurface" => length == 1 ? typeof(irsdk_TrkLoc) : typeof(irsdk_TrkLoc[]),
-                "CarIdxTrackSurfaceMaterial" => length == 1 ? typeof(irsdk_TrkSurf) : typeof(irsdk_TrkSurf[]),
-                "CarLeftRight" => length == 1 ? typeof(irsdk_CarLeftRight) : typeof(irsdk_CarLeftRight[]),
-                "PaceMode" => length == 1 ? typeof(irsdk_PaceMode) : typeof(irsdk_PaceMode[]),
-                "PlayerCarPitSvStatus" => length == 1 ? typeof(irsdk_PitSvStatus) : typeof(irsdk_PitSvStatus[]),
-                "PlayerTrackSurface" => length == 1 ? typeof(irsdk_TrkLoc) : typeof(irsdk_TrkLoc[]),
-                "PlayerTrackSurfaceMaterial" => length == 1 ? typeof(irsdk_TrkSurf) : typeof(irsdk_TrkSurf[]),
-                "SessionState" => length == 1 ? typeof(irsdk_SessionState) : typeof(irsdk_SessionState[]),
-                "TrackWetness" => length == 1 ? typeof(irsdk_TrackWetness) : typeof(irsdk_TrackWetness[]),
-                // otherwise int
+                "CarIdxTrackSurface" => length == 1 ? typeof(TrackLocation) : typeof(TrackLocation[]),
+                "CarIdxTrackSurfaceMaterial" => length == 1 ? typeof(TrackSurface) : typeof(TrackSurface[]),
+                "CarLeftRight" => length == 1 ? typeof(CarLeftRight) : typeof(CarLeftRight[]),
+                "PaceMode" => length == 1 ? typeof(PaceMode) : typeof(PaceMode[]),
+                "PlayerCarPitSvStatus" => length == 1 ? typeof(PitServiceStatus) : typeof(PitServiceStatus[]),
+                "PlayerTrackSurface" => length == 1 ? typeof(TrackLocation) : typeof(TrackLocation[]),
+                "PlayerTrackSurfaceMaterial" => length == 1 ? typeof(TrackSurface) : typeof(TrackSurface[]),
+                "SessionState" => length == 1 ? typeof(SessionState) : typeof(SessionState[]),
+                "TrackWetness" => length == 1 ? typeof(TrackWetness) : typeof(TrackWetness[]),
+                // default to int
                 _ => length == 1 ? typeof(int) : typeof(int[]),
             };
             return type;
@@ -187,12 +186,12 @@ namespace SVappsLAB.iRacingTelemetrySDK
         {
             var type = varName switch
             {
-                "CamCameraState" => length == 1 ? typeof(irsdk_CameraState) : typeof(irsdk_CameraState[]),
-                "CarIdxPaceFlags" => length == 1 ? typeof(irsdk_PaceFlags) : typeof(irsdk_PaceFlags[]),
-                "CarIdxSessionFlags" => length == 1 ? typeof(irsdk_Flags) : typeof(irsdk_Flags[]),
-                "EngineWarnings" => length == 1 ? typeof(irsdk_EngineWarnings) : typeof(irsdk_EngineWarnings[]),
-                "PitServiceFlags" => length == 1 ? typeof(irsdk_PitSvStatus) : typeof(irsdk_PitSvStatus[]),
-                "SessionFlags" => length == 1 ? typeof(irsdk_Flags) : typeof(irsdk_Flags[]),
+                "CamCameraState" => length == 1 ? typeof(CameraState) : typeof(CameraState[]),
+                "CarIdxPaceFlags" => length == 1 ? typeof(PaceFlags) : typeof(TrackSurface[]),
+                "CarIdxSessionFlags" => length == 1 ? typeof(SessionFlags) : typeof(SessionFlags[]),
+                "EngineWarnings" => length == 1 ? typeof(EngineWarnings) : typeof(EngineWarnings[]),
+                "PitServiceFlags" => length == 1 ? typeof(PitServiceStatus) : typeof(PitServiceStatus[]),
+                "SessionFlags" => length == 1 ? typeof(SessionFlags) : typeof(SessionFlags[]),
                 _ => throw new NotImplementedException(varName)
             };
             return type;

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/iRacingData.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/iRacingData.cs
@@ -1,12 +1,12 @@
 /**
  * Copyright (C)2024 Scott Velez
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,10 +14,10 @@
  * limitations under the License.using Microsoft.CodeAnalysis;
 **/
 
-/* 
+/*
  * This file is used by the code generation tooling to generate the TelemetryData structure with strongly typed properties.
  * It is NOT meant to be used directly.
- * 
+ *
 **/
 
 using System;
@@ -49,7 +49,7 @@ namespace SVappsLAB.iRacingTelemetrySDK
             { "CRshockVel", new VarItem("CRshockVel", 4, 1, false, "CR shock velocity", "m/s") },
             { "CRshockVel_ST", new VarItem("CRshockVel_ST", 4, 6, true, "CR shock velocity at 360 Hz", "m/s") },
             { "CamCameraNumber", new VarItem("CamCameraNumber", 2, 1, false, "Active camera number", "") },
-            { "CamCameraState", new VarItem("CamCameraState", 3, 1, false, "State of camera system", "irsdk_CameraState") },
+            { "CamCameraState", new VarItem("CamCameraState", 3, 1, false, "State of camera system", "CameraState") },
             { "CamCarIdx", new VarItem("CamCarIdx", 2, 1, false, "Active camera's focus car index", "") },
             { "CamGroupNumber", new VarItem("CamGroupNumber", 2, 1, false, "Active camera group number", "") },
             { "CarDistAhead", new VarItem("CarDistAhead", 4, 1, false, "Distance to first car in front of player in meters", "m") },
@@ -69,19 +69,19 @@ namespace SVappsLAB.iRacingTelemetrySDK
             { "CarIdxOnPitRoad", new VarItem("CarIdxOnPitRoad", 1, 64, false, "On pit road between the cones by car index", "") },
             { "CarIdxP2P_Count", new VarItem("CarIdxP2P_Count", 2, 64, false, "Push2Pass count of usage (or remaining in Race)", "") },
             { "CarIdxP2P_Status", new VarItem("CarIdxP2P_Status", 1, 64, false, "Push2Pass active or not", "") },
-            { "CarIdxPaceFlags", new VarItem("CarIdxPaceFlags", 3, 64, false, "Pacing status flags for each car", "irsdk_PaceFlags") },
+            { "CarIdxPaceFlags", new VarItem("CarIdxPaceFlags", 3, 64, false, "Pacing status flags for each car", "PaceFlags") },
             { "CarIdxPaceLine", new VarItem("CarIdxPaceLine", 2, 64, false, "What line cars are pacing in  or -1 if not pacing", "") },
             { "CarIdxPaceRow", new VarItem("CarIdxPaceRow", 2, 64, false, "What row cars are pacing in  or -1 if not pacing", "") },
             { "CarIdxPosition", new VarItem("CarIdxPosition", 2, 64, false, "Cars position in race by car index", "") },
             { "CarIdxQualTireCompound", new VarItem("CarIdxQualTireCompound", 2, 64, false, "Cars Qual tire compound", "") },
             { "CarIdxQualTireCompoundLocked", new VarItem("CarIdxQualTireCompoundLocked", 1, 64, false, "Cars Qual tire compound is locked-in", "") },
             { "CarIdxRPM", new VarItem("CarIdxRPM", 4, 64, false, "Engine rpm by car index", "revs/min") },
-            { "CarIdxSessionFlags", new VarItem("CarIdxSessionFlags", 3, 64, false, "Session flags for each player", "irsdk_Flags") },
+            { "CarIdxSessionFlags", new VarItem("CarIdxSessionFlags", 3, 64, false, "Session flags for each player", "SessionFlags") },
             { "CarIdxSteer", new VarItem("CarIdxSteer", 4, 64, false, "Steering wheel angle by car index", "rad") },
             { "CarIdxTireCompound", new VarItem("CarIdxTireCompound", 2, 64, false, "Cars current tire compound", "") },
-            { "CarIdxTrackSurface", new VarItem("CarIdxTrackSurface", 2, 64, false, "Track surface type by car index", "irsdk_TrkLoc") },
-            { "CarIdxTrackSurfaceMaterial", new VarItem("CarIdxTrackSurfaceMaterial", 2, 64, false, "Track surface material type by car index", "irsdk_TrkSurf") },
-            { "CarLeftRight", new VarItem("CarLeftRight", 2, 1, false, "Notify if car is to the left or right of driver", "irsdk_CarLeftRight") },
+            { "CarIdxTrackSurface", new VarItem("CarIdxTrackSurface", 2, 64, false, "Track surface type by car index", "TrackLocation") },
+            { "CarIdxTrackSurfaceMaterial", new VarItem("CarIdxTrackSurfaceMaterial", 2, 64, false, "Track surface material type by car index", "TrackSurface") },
+            { "CarLeftRight", new VarItem("CarLeftRight", 2, 1, false, "Notify if car is to the left or right of driver", "CarLeftRight") },
             { "ChanAvgLatency", new VarItem("ChanAvgLatency", 4, 1, false, "Communications average latency", "s") },
             { "ChanClockSkew", new VarItem("ChanClockSkew", 4, 1, false, "Communications server clock skew", "s") },
             { "ChanLatency", new VarItem("ChanLatency", 4, 1, false, "Communications latency", "s") },
@@ -96,7 +96,7 @@ namespace SVappsLAB.iRacingTelemetrySDK
             { "DisplayUnits", new VarItem("DisplayUnits", 2, 1, false, "Default units for the user interface 0 = english 1 = metric", "") },
             { "DriverMarker", new VarItem("DriverMarker", 1, 1, false, "Driver activated flag", "") },
             { "Engine0_RPM", new VarItem("Engine0_RPM", 4, 1, false, "Engine0Engine rpm", "revs/min") },
-            { "EngineWarnings", new VarItem("EngineWarnings", 3, 1, false, "Bitfield for warning lights", "irsdk_EngineWarnings") },
+            { "EngineWarnings", new VarItem("EngineWarnings", 3, 1, false, "Bitfield for warning lights", "EngineWarnings") },
             { "EnterExitReset", new VarItem("EnterExitReset", 2, 1, false, "Indicate action the reset key will take 0 enter 1 exit 2 reset", "") },
             { "FastRepairAvailable", new VarItem("FastRepairAvailable", 2, 1, false, "How many fast repairs left  255 is unlimited", "") },
             { "FastRepairUsed", new VarItem("FastRepairUsed", 2, 1, false, "How many fast repairs used so far", "") },
@@ -214,10 +214,10 @@ namespace SVappsLAB.iRacingTelemetrySDK
             { "OnPitRoad", new VarItem("OnPitRoad", 1, 1, false, "Is the player car on pit road between the cones", "") },
             { "P2P_Count", new VarItem("P2P_Count", 2, 1, false, "Push2Pass count of usage (or remaining in Race) on your car", "") },
             { "P2P_Status", new VarItem("P2P_Status", 1, 1, false, "Push2Pass active or not on your car", "") },
-            { "PaceMode", new VarItem("PaceMode", 2, 1, false, "Are we pacing or not", "irsdk_PaceMode") },
+            { "PaceMode", new VarItem("PaceMode", 2, 1, false, "Are we pacing or not", "PaceMode") },
             { "PitOptRepairLeft", new VarItem("PitOptRepairLeft", 4, 1, false, "Time left for optional repairs if repairs are active", "s") },
             { "PitRepairLeft", new VarItem("PitRepairLeft", 4, 1, false, "Time left for mandatory pit repairs if repairs are active", "s") },
-            { "PitSvFlags", new VarItem("PitSvFlags", 3, 1, false, "Bitfield of pit service checkboxes", "irsdk_PitSvFlags") },
+            { "PitServiceFlags", new VarItem("PitServiceFlags", 3, 1, false, "Bitfield of pit service checkboxes", "PitServiceFlags") },
             { "PitSvFuel", new VarItem("PitSvFuel", 4, 1, false, "Pit service fuel add amount", "l or kWh") },
             { "PitSvLFP", new VarItem("PitSvLFP", 4, 1, false, "Pit service left front tire pressure", "kPa") },
             { "PitSvLRP", new VarItem("PitSvLRP", 4, 1, false, "Pit service left rear tire pressure", "kPa") },
@@ -236,7 +236,7 @@ namespace SVappsLAB.iRacingTelemetrySDK
             { "PlayerCarIdx", new VarItem("PlayerCarIdx", 2, 1, false, "Players carIdx", "") },
             { "PlayerCarInPitStall", new VarItem("PlayerCarInPitStall", 1, 1, false, "Players car is properly in their pitstall", "") },
             { "PlayerCarMyIncidentCount", new VarItem("PlayerCarMyIncidentCount", 2, 1, false, "Players own incident count for this session", "") },
-            { "PlayerCarPitSvStatus", new VarItem("PlayerCarPitSvStatus", 2, 1, false, "Players car pit service status bits", "irsdk_PitSvStatus") },
+            { "PlayerCarPitSvStatus", new VarItem("PlayerCarPitSvStatus", 2, 1, false, "Players car pit service status bits", "PitServiceStatus") },
             { "PlayerCarPosition", new VarItem("PlayerCarPosition", 2, 1, false, "Players position in race", "") },
             { "PlayerCarPowerAdjust", new VarItem("PlayerCarPowerAdjust", 4, 1, false, "Players power adjust", "%") },
             { "PlayerCarSLBlinkRPM", new VarItem("PlayerCarSLBlinkRPM", 4, 1, false, "Shift light blink rpm", "revs/min") },
@@ -248,8 +248,8 @@ namespace SVappsLAB.iRacingTelemetrySDK
             { "PlayerCarWeightPenalty", new VarItem("PlayerCarWeightPenalty", 4, 1, false, "Players weight penalty", "kg") },
             { "PlayerFastRepairsUsed", new VarItem("PlayerFastRepairsUsed", 2, 1, false, "Players car number of fast repairs used", "") },
             { "PlayerTireCompound", new VarItem("PlayerTireCompound", 2, 1, false, "Players car current tire compound", "") },
-            { "PlayerTrackSurface", new VarItem("PlayerTrackSurface", 2, 1, false, "Players car track surface type", "irsdk_TrkLoc") },
-            { "PlayerTrackSurfaceMaterial", new VarItem("PlayerTrackSurfaceMaterial", 2, 1, false, "Players car track surface material type", "irsdk_TrkSurf") },
+            { "PlayerTrackSurface", new VarItem("PlayerTrackSurface", 2, 1, false, "Players car track surface type", "TrackLocation") },
+            { "PlayerTrackSurfaceMaterial", new VarItem("PlayerTrackSurfaceMaterial", 2, 1, false, "Players car track surface material type", "TrackSurface") },
             { "Precipitation", new VarItem("Precipitation", 4, 1, false, "Precipitation at start/finish line", "%") },
             { "PushToPass", new VarItem("PushToPass", 1, 1, false, "Push to pass button state", "") },
             { "PushToTalk", new VarItem("PushToTalk", 1, 1, false, "Push to talk button state", "") },
@@ -316,14 +316,14 @@ namespace SVappsLAB.iRacingTelemetrySDK
             { "Roll", new VarItem("Roll", 4, 1, false, "Roll orientation", "rad") },
             { "RollRate", new VarItem("RollRate", 4, 1, false, "Roll rate", "rad/s") },
             { "RollRate_ST", new VarItem("RollRate_ST", 4, 6, true, "Roll rate at 360 Hz", "rad/s") },
-            { "SessionFlags", new VarItem("SessionFlags", 3, 1, false, "Session flags", "irsdk_Flags") },
+            { "SessionFlags", new VarItem("SessionFlags", 3, 1, false, "Session flags", "SessionFlags") },
             { "SessionJokerLapsRemain", new VarItem("SessionJokerLapsRemain", 2, 1, false, "Joker laps remaining to be taken", "") },
             { "SessionLapsRemain", new VarItem("SessionLapsRemain", 2, 1, false, "Old laps left till session ends use SessionLapsRemainEx", "") },
             { "SessionLapsRemainEx", new VarItem("SessionLapsRemainEx", 2, 1, false, "New improved laps left till session ends", "") },
             { "SessionLapsTotal", new VarItem("SessionLapsTotal", 2, 1, false, "Total number of laps in session", "") },
             { "SessionNum", new VarItem("SessionNum", 2, 1, false, "Session number", "") },
             { "SessionOnJokerLap", new VarItem("SessionOnJokerLap", 1, 1, false, "Player is currently completing a joker lap", "") },
-            { "SessionState", new VarItem("SessionState", 2, 1, false, "Session state", "irsdk_SessionState") },
+            { "SessionState", new VarItem("SessionState", 2, 1, false, "Session state", "SessionState") },
             { "SessionTick", new VarItem("SessionTick", 2, 1, false, "Current update number", "") },
             { "SessionTime", new VarItem("SessionTime", 5, 1, false, "Seconds since session start", "s") },
             { "SessionTimeOfDay", new VarItem("SessionTimeOfDay", 4, 1, false, "Time of day in seconds", "s") },
@@ -361,7 +361,7 @@ namespace SVappsLAB.iRacingTelemetrySDK
             { "TireSetsUsed", new VarItem("TireSetsUsed", 2, 1, false, "How many tire sets used so far", "") },
             { "TrackTemp", new VarItem("TrackTemp", 4, 1, false, "Deprecated  set to TrackTempCrew", "C") },
             { "TrackTempCrew", new VarItem("TrackTempCrew", 4, 1, false, "Temperature of track measured by crew around track", "C") },
-            { "TrackWetness", new VarItem("TrackWetness", 2, 1, false, "How wet is the average track surface", "irsdk_TrackWetness") },
+            { "TrackWetness", new VarItem("TrackWetness", 2, 1, false, "How wet is the average track surface", "TrackWetness") },
             { "VelocityX", new VarItem("VelocityX", 4, 1, false, "X velocity", "m/s") },
             { "VelocityX_ST", new VarItem("VelocityX_ST", 4, 6, true, "X velocity", "m/s at 360 Hz") },
             { "VelocityY", new VarItem("VelocityY", 4, 1, false, "Y velocity", "m/s") },
@@ -376,8 +376,8 @@ namespace SVappsLAB.iRacingTelemetrySDK
             { "WaterLevel", new VarItem("WaterLevel", 4, 1, false, "Engine coolant level", "l") },
             { "WaterTemp", new VarItem("WaterTemp", 4, 1, false, "Engine coolant temp", "C") },
             { "WeatherDeclaredWet", new VarItem("WeatherDeclaredWet", 1, 1, false, "The steward says rain tires can be used", "") },
-            // removed { "WeatherType", new VarItem("WeatherType", 2, 1, false, "Weather dynamics type", "irsdk_WeatherDynamics") },
-            // removed { "WeatherVersion", new VarItem("WeatherVersion", 2, 1, false, "Weather version", "irsdk_WeatherVersion") },
+            // removed { "WeatherType", new VarItem("WeatherType", 2, 1, false, "Weather dynamics type", "WeatherDynamics") },
+            // removed { "WeatherVersion", new VarItem("WeatherVersion", 2, 1, false, "Weather version", "WeatherVersion") },
             { "WindDir", new VarItem("WindDir", 4, 1, false, "Wind direction at start/finish line", "rad") },
             { "WindVel", new VarItem("WindVel", 4, 1, false, "Wind velocity at start/finish line", "m/s") },
             { "Yaw", new VarItem("Yaw", 4, 1, false, "Yaw orientation", "rad") },

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK.EnumsAndFlags/TelemetryClient_Enums.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK.EnumsAndFlags/TelemetryClient_Enums.cs
@@ -18,108 +18,108 @@
 // enums
 namespace SVappsLAB.iRacingTelemetrySDK
 {
-    public enum irsdk_TrkLoc
+    public enum TrackLocation
     {
-        irsdk_NotInWorld = -1,
-        irsdk_OffTrack = 0,
-        irsdk_InPitStall,
+        NotInWorld = -1,
+        OffTrack = 0,
+        InPitStall,
         // This indicates the lead in to pit road, as well as the pit road itself (where speed limits are enforced)
         // if you just want to know that your on the pit road surface look at the live value 'OnPitRoad'
-        irsdk_AproachingPits,
-        irsdk_OnTrack
+        AproachingPits,
+        OnTrack
     };
 
-    public enum irsdk_TrkSurf
+    public enum TrackSurface
     {
-        irsdk_SurfaceNotInWorld = -1,
-        irsdk_UndefinedMaterial = 0,
+        SurfaceNotInWorld = -1,
+        UndefinedMaterial = 0,
 
-        irsdk_Asphalt1Material,
-        irsdk_Asphalt2Material,
-        irsdk_Asphalt3Material,
-        irsdk_Asphalt4Material,
-        irsdk_Concrete1Material,
-        irsdk_Concrete2Material,
-        irsdk_RacingDirt1Material,
-        irsdk_RacingDirt2Material,
-        irsdk_Paint1Material,
-        irsdk_Paint2Material,
-        irsdk_Rumble1Material,
-        irsdk_Rumble2Material,
-        irsdk_Rumble3Material,
-        irsdk_Rumble4Material,
+        Asphalt1Material,
+        Asphalt2Material,
+        Asphalt3Material,
+        Asphalt4Material,
+        Concrete1Material,
+        Concrete2Material,
+        RacingDirt1Material,
+        RacingDirt2Material,
+        Paint1Material,
+        Paint2Material,
+        Rumble1Material,
+        Rumble2Material,
+        Rumble3Material,
+        Rumble4Material,
 
-        irsdk_Grass1Material,
-        irsdk_Grass2Material,
-        irsdk_Grass3Material,
-        irsdk_Grass4Material,
-        irsdk_Dirt1Material,
-        irsdk_Dirt2Material,
-        irsdk_Dirt3Material,
-        irsdk_Dirt4Material,
-        irsdk_SandMaterial,
-        irsdk_Gravel1Material,
-        irsdk_Gravel2Material,
-        irsdk_GrasscreteMaterial,
-        irsdk_AstroturfMaterial,
+        Grass1Material,
+        Grass2Material,
+        Grass3Material,
+        Grass4Material,
+        Dirt1Material,
+        Dirt2Material,
+        Dirt3Material,
+        Dirt4Material,
+        SandMaterial,
+        Gravel1Material,
+        Gravel2Material,
+        GrasscreteMaterial,
+        AstroturfMaterial,
     };
 
-    public enum irsdk_SessionState
+    public enum SessionState
     {
-        irsdk_StateInvalid = 0,
-        irsdk_StateGetInCar,
-        irsdk_StateWarmup,
-        irsdk_StateParadeLaps,
-        irsdk_StateRacing,
-        irsdk_StateCheckered,
-        irsdk_StateCoolDown
+        Invalid = 0,
+        GetInCar,
+        Warmup,
+        ParadeLaps,
+        Racing,
+        Checkered,
+        CoolDown
     };
 
-    public enum irsdk_CarLeftRight
+    public enum CarLeftRight
     {
-        irsdk_LROff = 0,
-        irsdk_LRClear,          // no cars around us.
-        irsdk_LRCarLeft,        // there is a car to our left.
-        irsdk_LRCarRight,       // there is a car to our right.
-        irsdk_LRCarLeftRight,   // there are cars on each side.
-        irsdk_LR2CarsLeft,      // there are two cars to our left.
-        irsdk_LR2CarsRight      // there are two cars to our right.
+        Off = 0,
+        Clear,          // no cars around us.
+        CarLeft,        // there is a car to our left.
+        CarRight,       // there is a car to our right.
+        CarLeftRight,   // there are cars on each side.
+        TwoCarsLeft,    // there are two cars to our left.
+        TwoCarsRight    // there are two cars to our right.
     };
 
-    public enum irsdk_PitSvStatus
+    public enum PitServiceStatus
     {
         // status
-        irsdk_PitSvNone = 0,
-        irsdk_PitSvInProgress,
-        irsdk_PitSvComplete,
+        None = 0,
+        InProgress,
+        Complete,
 
         // errors
-        irsdk_PitSvTooFarLeft = 100,
-        irsdk_PitSvTooFarRight,
-        irsdk_PitSvTooFarForward,
-        irsdk_PitSvTooFarBack,
-        irsdk_PitSvBadAngle,
-        irsdk_PitSvCantFixThat,
+        TooFarLeft = 100,
+        TooFarRight,
+        TooFarForward,
+        TooFarBack,
+        BadAngle,
+        CantFixThat,
     };
 
-    public enum irsdk_PaceMode
+    public enum PaceMode
     {
-        irsdk_PaceModeSingleFileStart = 0,
-        irsdk_PaceModeDoubleFileStart,
-        irsdk_PaceModeSingleFileRestart,
-        irsdk_PaceModeDoubleFileRestart,
-        irsdk_PaceModeNotPacing,
+        SingleFileStart = 0,
+        DoubleFileStart,
+        SingleFileRestart,
+        DoubleFileRestart,
+        NotPacing,
     };
 
-    public enum irsdk_TrackWetness
+    public enum TrackWetness
     {
-        irsdk_TrackWetness_UNKNOWN = 0,
-        irsdk_TrackWetness_Dry,
-        irsdk_TrackWetness_MostlyDry,
-        irsdk_TrackWetness_VeryLightlyWet,
-        irsdk_TrackWetness_LightlyWet,
-        irsdk_TrackWetness_ModeratelyWet,
-        irsdk_TrackWetness_VeryWet,
-        irsdk_TrackWetness_ExtremelyWet
+        Unknown = 0,
+        Dry,
+        MostlyDry,
+        VeryLightlyWet,
+        LightlyWet,
+        ModeratelyWet,
+        VeryWet,
+        ExtremelyWet
     };
 }

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK.EnumsAndFlags/TelemetryClient_Flags.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK.EnumsAndFlags/TelemetryClient_Flags.cs
@@ -1,12 +1,12 @@
 /**
  * Copyright (C)2024 Scott Velez
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,87 +20,87 @@ using System;
 namespace SVappsLAB.iRacingTelemetrySDK
 {
     [Flags]
-    public enum irsdk_EngineWarnings
+    public enum EngineWarnings
     {
-        irsdk_waterTempWarning = 0x0001,
-        irsdk_fuelPressureWarning = 0x0002,
-        irsdk_oilPressureWarning = 0x0004,
-        irsdk_engineStalled = 0x0008,
-        irsdk_pitSpeedLimiter = 0x0010,
-        irsdk_revLimiterActive = 0x0020,
-        irsdk_oilTempWarning = 0x0040,
+        WaterTempWarning = 0x0001,
+        FuelPressureWarning = 0x0002,
+        OilPressureWarning = 0x0004,
+        EngineStalled = 0x0008,
+        PitSpeedLimiter = 0x0010,
+        RevLimiterActive = 0x0020,
+        OilTempWarning = 0x0040,
     };
 
     // global flags
     [Flags]
-    public enum irsdk_Flags
+    public enum SessionFlags
     {
         // global flags
-        irsdk_checkered = 0x00000001,
-        irsdk_white = 0x00000002,
-        irsdk_green = 0x00000004,
-        irsdk_yellow = 0x00000008,
-        irsdk_red = 0x00000010,
-        irsdk_blue = 0x00000020,
-        irsdk_debris = 0x00000040,
-        irsdk_crossed = 0x00000080,
-        irsdk_yellowWaving = 0x00000100,
-        irsdk_oneLapToGreen = 0x00000200,
-        irsdk_greenHeld = 0x00000400,
-        irsdk_tenToGo = 0x00000800,
-        irsdk_fiveToGo = 0x00001000,
-        irsdk_randomWaving = 0x00002000,
-        irsdk_caution = 0x00004000,
-        irsdk_cautionWaving = 0x00008000,
+        Checkered = 0x00000001,
+        White = 0x00000002,
+        Green = 0x00000004,
+        Yellow = 0x00000008,
+        Red = 0x00000010,
+        Blue = 0x00000020,
+        Debris = 0x00000040,
+        Crossed = 0x00000080,
+        YellowWaving = 0x00000100,
+        OneLapToGreen = 0x00000200,
+        GreenHeld = 0x00000400,
+        TenToGo = 0x00000800,
+        FiveToGo = 0x00001000,
+        RandomWaving = 0x00002000,
+        Caution = 0x00004000,
+        CautionWaving = 0x00008000,
 
         // drivers black flags
-        irsdk_black = 0x00010000,
-        irsdk_disqualify = 0x00020000,
-        irsdk_servicible = 0x00040000, // car is allowed service (not a flag)
-        irsdk_furled = 0x00080000,
-        irsdk_repair = 0x00100000,
+        Black = 0x00010000,
+        Disqualify = 0x00020000,
+        Serviceable = 0x00040000, // car is allowed service (not a flag)
+        Furled = 0x00080000,
+        Repair = 0x00100000,
 
         // start lights
-        irsdk_startHidden = 0x10000000,
-        irsdk_startReady = 0x20000000,
-        irsdk_startSet = 0x40000000,
-        irsdk_startgo = unchecked((int)0x80000000),
+        StartHidden = 0x10000000,
+        StartReady = 0x20000000,
+        StartSet = 0x40000000,
+        StartGo = unchecked((int)0x80000000),
     };
 
     [Flags]
-    public enum irsdk_CameraState
+    public enum CameraState
     {
-        irsdk_IsSessionScreen = 0x0001, // the camera tool can only be activated if viewing the session screen (out of car)
-        irsdk_IsScenicActive = 0x0002, // the scenic camera is active (no focus car)
+        IsSessionScreen = 0x0001, // the camera tool can only be activated if viewing the session screen (out of car)
+        IsScenicActive = 0x0002, // the scenic camera is active (no focus car)
 
         //these can be changed with a broadcast message
-        irsdk_CamToolActive = 0x0004,
-        irsdk_UIHidden = 0x0008,
-        irsdk_UseAutoShotSelection = 0x0010,
-        irsdk_UseTemporaryEdits = 0x0020,
-        irsdk_UseKeyAcceleration = 0x0040,
-        irsdk_UseKey10xAcceleration = 0x0080,
-        irsdk_UseMouseAimMode = 0x0100
+        CamToolActive = 0x0004,
+        UIHidden = 0x0008,
+        UseAutoShotSelection = 0x0010,
+        UseTemporaryEdits = 0x0020,
+        UseKeyAcceleration = 0x0040,
+        UseKey10xAcceleration = 0x0080,
+        UseMouseAimMode = 0x0100
     };
 
     [Flags]
-    public enum irsdk_PitSvFlags
+    public enum PitServiceFlags
     {
-        irsdk_LFTireChange = 0x0001,
-        irsdk_RFTireChange = 0x0002,
-        irsdk_LRTireChange = 0x0004,
-        irsdk_RRTireChange = 0x0008,
+        LFTireChange = 0x0001,
+        RFTireChange = 0x0002,
+        LRTireChange = 0x0004,
+        RRTireChange = 0x0008,
 
-        irsdk_FuelFill = 0x0010,
-        irsdk_WindshieldTearoff = 0x0020,
-        irsdk_FastRepair = 0x0040
+        FuelFill = 0x0010,
+        WindshieldTearoff = 0x0020,
+        FastRepair = 0x0040
     };
 
     [Flags]
-    public enum irsdk_PaceFlags
+    public enum PaceFlags
     {
-        irsdk_PaceFlagsEndOfLine = 0x0001,
-        irsdk_PaceFlagsFreePass = 0x0002,
-        irsdk_PaceFlagsWavedAround = 0x0004,
+        EndOfLine = 0x0001,
+        FreePass = 0x0002,
+        WavedAround = 0x0004,
     };
 }

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/SVappsLAB.iRacingTelemetrySDK.csproj
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/SVappsLAB.iRacingTelemetrySDK.csproj
@@ -35,7 +35,7 @@
 		<PackageTags>iRacing iRacingSDK irsdk IBT Telemetry SDK API</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>0.8.0</Version>
+		<Version>0.9.0</Version>
 		<Authors>Scott Velez</Authors>
 		<Company>SVappsLAB</Company>
 		<Copyright>Copyright (c) 2025 SVappsLAB</Copyright>

--- a/Sdk/tests/Live_Tests/Telemetry.cs
+++ b/Sdk/tests/Live_Tests/Telemetry.cs
@@ -1,12 +1,12 @@
 /**
  * Copyright (C)2024 Scott Velez
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -80,9 +80,9 @@ namespace Live_Tests
             telemetryClient.OnTelemetryUpdate += onNewTelemetryData;
 
             // telemetry data we expect to receive
-            irsdk_EngineWarnings engineWarnings = 0;
+            EngineWarnings engineWarnings = 0;
             var isOnTrackCar = false;
-            irsdk_TrkLoc playerTrackSurface = irsdk_TrkLoc.irsdk_NotInWorld;
+            TrackLocation playerTrackSurface = TrackLocation.NotInWorld;
             var rpm = 0.0f;
             var sessionTick = 0.0d;
             var sessionTimeRemain = 0.0d;
@@ -103,7 +103,7 @@ namespace Live_Tests
                 // test doubles
                 sessionTimeRemain = e.SessionTimeRemain;
 
-                // we receieved data. cancel monitoring
+                // we received data. cancel monitoring
                 cts.Cancel();
             }
 
@@ -126,8 +126,8 @@ namespace Live_Tests
             Assert.True(isOnTrackCar, "IsOnTrackCar is false");
 
             var isValidTrackSurface =
-                (irsdk_TrkLoc)playerTrackSurface == irsdk_TrkLoc.irsdk_InPitStall ||
-                (irsdk_TrkLoc)playerTrackSurface == irsdk_TrkLoc.irsdk_OnTrack;
+                playerTrackSurface == TrackLocation.InPitStall ||
+                playerTrackSurface == TrackLocation.OnTrack;
             Assert.True(isValidTrackSurface, "PlayerTrackSurface is not 0");
 
             Assert.True(rpm > 0, "rpm should be greater than 0");


### PR DESCRIPTION
refactor enum and flag names  
remove `irsdk_` prefix which is inconsistient with .net naming conventions
