### PR TITLE
Refactor data access

### DIFF
--- a/Samples/DumpVariables_DumpSessionInfo/DumpVariables_DumpSessionInfo.csproj
+++ b/Samples/DumpVariables_DumpSessionInfo/DumpVariables_DumpSessionInfo.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
-    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.1" />
+    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.2" />
   </ItemGroup>
 
 </Project>

--- a/Samples/DumpVariables_DumpSessionInfo/DumpVariables_DumpSessionInfo.csproj
+++ b/Samples/DumpVariables_DumpSessionInfo/DumpVariables_DumpSessionInfo.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
+    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.1" />
   </ItemGroup>
 
 </Project>

--- a/Samples/LocationAndWarnings/LocationAndWarnings.csproj
+++ b/Samples/LocationAndWarnings/LocationAndWarnings.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
-    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.1" />
+    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.2" />
   </ItemGroup>
 
 </Project>

--- a/Samples/LocationAndWarnings/LocationAndWarnings.csproj
+++ b/Samples/LocationAndWarnings/LocationAndWarnings.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
+    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.1" />
   </ItemGroup>
 
 </Project>

--- a/Samples/SpeedRPMGear/SpeedRPMGear.csproj
+++ b/Samples/SpeedRPMGear/SpeedRPMGear.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
-    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.1" />
+    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.2" />
   </ItemGroup>
 
 </Project>

--- a/Samples/SpeedRPMGear/SpeedRPMGear.csproj
+++ b/Samples/SpeedRPMGear/SpeedRPMGear.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
-    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
+    <PackageReference Include="SVappsLAB.iRacingTelemetrySDK" Version="0.9.1" />
   </ItemGroup>
 
 </Project>

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/CodeGen.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/CodeGen.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/SVappsLAB.iRacingTelemetrySDK.CodeGen.csproj
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/SVappsLAB.iRacingTelemetrySDK.CodeGen.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/iRacingData.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/iRacingData.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/tools/vars/csv-to-cs.py
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/tools/vars/csv-to-cs.py
@@ -1,5 +1,5 @@
 #**
- # Copyright (C)2024 Scott Velez
+ # Copyright (C) 2024-2025 Scott Velez
  # 
  # Licensed under the Apache License, Version 2.0 (the "License");
  # you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/tools/vars/findDistinctVars.py
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK.CodeGen/tools/vars/findDistinctVars.py
@@ -1,5 +1,5 @@
 #**
- # Copyright (C)2024 Scott Velez
+ # Copyright (C) 2024-2025 Scott Velez
  # 
  # Licensed under the Apache License, Version 2.0 (the "License");
  # you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK.EnumsAndFlags/TelemetryClient_Enums.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK.EnumsAndFlags/TelemetryClient_Enums.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK.EnumsAndFlags/TelemetryClient_Flags.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK.EnumsAndFlags/TelemetryClient_Flags.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/DataProviders/IBTDataProvider.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/DataProviders/IBTDataProvider.cs
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2024-2025 Scott Velez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.using Microsoft.CodeAnalysis;
+**/
+
+using System;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using SVappsLAB.iRacingTelemetrySDK.IBTPlayback;
+using SVappsLAB.iRacingTelemetrySDK.irSDKDefines;
+
+namespace SVappsLAB.iRacingTelemetrySDK.DataProviders
+{
+    internal unsafe class IBTDataProvider : DataProviderBase, IDataProvider
+    {
+        readonly IBTOptions _ibtOptions;
+        readonly IPlaybackGovernor _governor;
+        int _numRecords = 0;
+        int _currentRecord = 0;
+
+        public IBTDataProvider(ILogger logger, IBTOptions ibtOptions) : base(logger)
+        {
+
+            if (!File.Exists(ibtOptions.IbtFilePath))
+            {
+                throw new FileNotFoundException($"IBT file [{ibtOptions.IbtFilePath}] not found", ibtOptions.IbtFilePath);
+            }
+
+            _ibtOptions = ibtOptions;
+            _governor = new SimpleGovernor(_logger, _ibtOptions!.PlayBackSpeedMultiplier);
+        }
+
+        public override void OpenDataSource()
+        {
+            // open in shared mode so multiple processes (or tests) can access the same file
+            _mmFile = MemoryMappedFile.CreateFromFile(_ibtOptions.IbtFilePath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            _viewAccessor = _mmFile.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+            _viewAccessor!.SafeMemoryMappedViewHandle.AcquirePointer(ref _dataPtr);
+
+            // read header 
+            _header = GetHeader();
+
+            _numRecords = GetNumRecordsInIBTFile();
+
+            _governor.StartPlayback();
+        }
+
+        public int GetNumRecordsInIBTFile()
+        {
+            var numRecs = GetDiskSubHeader().sessionRecordCount;
+            return numRecs;
+        }
+
+        // wait for iRacing to signal there is new data
+        public override bool WaitForDataReady(TimeSpan _timeSpan)
+        {
+            // throttle playback speed
+            _governor.GovernSpeed(_currentRecord).Wait();
+
+            CopyNewTelemetryDataToBuffer(_currentRecord);
+
+            _currentRecord++;
+
+            // return true if there is more data to process
+            return _currentRecord < _numRecords;
+        }
+
+        irsdk_diskSubHeader GetDiskSubHeader()
+        {
+            // the disksubheader is located after the header
+            var offset = sizeof(irsdk_header);
+
+            var ros = new ReadOnlySpan<byte>(_dataPtr + offset, sizeof(irsdk_diskSubHeader));
+            var diskSubHeader = MemoryMarshal.AsRef<irsdk_diskSubHeader>(ros);
+
+            return diskSubHeader;
+        }
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/DataProviders/IDataProvider.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/DataProviders/IDataProvider.cs
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2024-2025 Scott Velez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.using Microsoft.CodeAnalysis;
+**/
+
+using System;
+using System.Collections.Generic;
+using SVappsLAB.iRacingTelemetrySDK.irSDKDefines;
+
+namespace SVappsLAB.iRacingTelemetrySDK.DataProviders
+{
+    internal interface IDataProvider : IDisposable
+    {
+        void OpenDataSource();
+        /// <summary>
+        /// Gets a value indicating whether a connection to the data source is established.
+        /// </summary>
+        bool IsConnected { get; }
+
+        /// <summary>
+        /// Checks if the session information has been updated since the last check.
+        /// </summary>
+        /// <returns>True if session information was updated; otherwise, false.</returns>
+        bool IsSessionInfoUpdated();
+
+        /// <summary>
+        /// Gets the current iRacing SDK header containing telemetry session metadata.
+        /// </summary>
+        /// <returns>The current iRacing SDK header.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the data source is not open.</exception>
+        irsdk_header GetHeader();
+
+        /// <summary>
+        /// Gets the session information as YAML text.
+        /// </summary>
+        /// <returns>The session information in YAML format, or an empty string if not available.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the memory view is not acquired.</exception>
+        string GetSessionInfoYaml();
+
+        /// <summary>
+        /// Gets the dictionary of variable headers that describe available telemetry variables.
+        /// </summary>
+        /// <returns>A dictionary of variable headers, or null if headers are not initialized.</returns>
+        VarHeaderDictionary? GetVarHeaders();
+
+        /// <summary>
+        /// Gets the value of a telemetry variable by name.
+        /// </summary>
+        /// <param name="varName">The name of the variable to retrieve.</param>
+        /// <returns>The value of the variable, which could be a scalar or an array.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when variable headers or telemetry buffer are not initialized.</exception>
+        /// <exception cref="KeyNotFoundException">Thrown when the specified variable name does not exist.</exception>
+        /// <exception cref="IndexOutOfRangeException">Thrown when the variable's data would exceed buffer boundaries.</exception>
+        object GetVarValue(string varName);
+
+        /// <summary>
+        /// Waits for new telemetry data to become available.
+        /// </summary>
+        /// <param name="timeout">Maximum time to wait for new data.</param>
+        /// <returns>True if new data is available; otherwise, false (timeout).</returns>
+        bool WaitForDataReady(TimeSpan timeout);
+    }
+}

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/DataProviders/LiveDataProvider.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/DataProviders/LiveDataProvider.cs
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2024-2025 Scott Velez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.using Microsoft.CodeAnalysis;
+**/
+
+using System;
+using System.IO.MemoryMappedFiles;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+using SVappsLAB.iRacingTelemetrySDK.irSDKDefines;
+
+namespace SVappsLAB.iRacingTelemetrySDK.DataProviders
+{
+    internal unsafe class LiveDataProvider : DataProviderBase, IDataProvider
+    {
+        const string IRSDK_MemMapFileName = @"Local\IRSDKMemMapFileName";
+        const string IRSDK_DataValidEventName = @"Local\IRSDKDataValidEvent";
+        const int SYNCHRONIZE = 0x00100000; // access right for synchronization
+
+        int _dataDropCount = 0;
+        int _lastTickCount = 0; // latest tick count iRacing wrote to
+        AutoResetEvent? _dataReadyEvent;
+
+        public LiveDataProvider(ILogger logger) : base(logger)
+        {
+        }
+
+        public override void OpenDataSource()
+        {
+            _mmFile = MemoryMappedFile.OpenExisting(IRSDK_MemMapFileName);
+            _viewAccessor = _mmFile.CreateViewAccessor();
+            _viewAccessor!.SafeMemoryMappedViewHandle.AcquirePointer(ref _dataPtr);
+
+            // read header 
+            _header = GetHeader();
+
+            // data ready event
+            var rawEvent = PInvoke.OpenEvent(SYNCHRONIZE, false, IRSDK_DataValidEventName);
+            _dataReadyEvent = new AutoResetEvent(false) { SafeWaitHandle = new Microsoft.Win32.SafeHandles.SafeWaitHandle(rawEvent, true) };
+        }
+
+        public override bool WaitForDataReady(TimeSpan timeSpan)
+        {
+            var signaled = _dataReadyEvent!.WaitOne(timeSpan);
+            if (!signaled)
+            {
+                _logger.LogDebug("timeout waiting for data ready event");
+                return false;
+            }
+
+            var latestTickCount = GetLatestVarBuff().tickCount;
+
+            // if we missed any telemetry data, log that it happened
+            if (latestTickCount > _lastTickCount)
+            {
+                var tickDiff = latestTickCount - _lastTickCount - 1;
+                if (_lastTickCount != 0 && tickDiff > 0)
+                {
+                    _dataDropCount += tickDiff;
+                    _logger.LogWarning("dropped {count} data records. {total} total. last tick: {lastTick}, current tick: {currentTick}", tickDiff, _dataDropCount, _lastTickCount, latestTickCount);
+                }
+            }
+
+            // did we loose sync?  perhaps we disconnected or a new session started
+            // log that it happened. we will resync below
+            if (latestTickCount < _lastTickCount)
+            {
+                _logger.LogDebug("new data is older than our last sample. lost connection?  will resync");
+            }
+
+            // copy new data to the access buffer for later reading
+            CopyNewTelemetryDataToBuffer();
+            // resync - update our last tick count
+            _lastTickCount = latestTickCount;
+
+            return true;
+        }
+
+        irsdk_varBuf GetLatestVarBuff()
+        {
+            var header = GetHeader();
+
+            var vb = header.varBuf1;
+            if (header.varBuf2.tickCount > vb.tickCount)
+                vb = header.varBuf2;
+            if (header.varBuf3.tickCount > vb.tickCount)
+                vb = header.varBuf3;
+            if (header.varBuf4.tickCount > vb.tickCount)
+                vb = header.varBuf4;
+            return vb;
+
+        }
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_dataReadyEvent != null)
+                {
+                    _dataReadyEvent.Dispose();
+                    _dataReadyEvent = null;
+                }
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/IBTPlayback/Governor.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/IBTPlayback/Governor.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/ITelemetryClient.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/ITelemetryClient.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,11 @@
  * limitations under the License.using Microsoft.CodeAnalysis;
 **/
 
-using SVappsLAB.iRacingTelemetrySDK.Models;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using SVappsLAB.iRacingTelemetrySDK.Models;
 
 namespace SVappsLAB.iRacingTelemetrySDK
 {

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/CameraInfo.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/CameraInfo.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/DriverInfo.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/DriverInfo.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/QualifyResultsInfo.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/QualifyResultsInfo.cs
@@ -1,21 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.using Microsoft.CodeAnalysis;
-**/
-
-/**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/RadioInfo.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/RadioInfo.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/SessionInfo.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/SessionInfo.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/SplitTimeInfo.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/SplitTimeInfo.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/TelemetrySessionInfo.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/TelemetrySessionInfo.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/WeekendInfo.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/Models/WeekendInfo.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/PInvoke.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/PInvoke.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ namespace SVappsLAB.iRacingTelemetrySDK
     internal class PInvoke
     {
         [DllImport("kernel32.dll", SetLastError = true)]
-        public static extern IntPtr OpenEvent(uint dwDesiredAccess, bool bInheritHandle, string lpName);
+        public static extern nint OpenEvent(uint dwDesiredAccess, bool bInheritHandle, string lpName);
 
         [DllImport("kernel32.dll")]
-        public static extern bool CloseHandle(IntPtr hObject);
+        public static extern bool CloseHandle(nint hObject);
     }
 }

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/SVappsLAB.iRacingTelemetrySDK.csproj
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/SVappsLAB.iRacingTelemetrySDK.csproj
@@ -35,7 +35,7 @@
 		<PackageTags>iRacing iRacingSDK irsdk IBT Telemetry SDK API</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>0.9.1</Version>
+		<Version>0.9.2</Version>
 		<Authors>Scott Velez</Authors>
 		<Company>SVappsLAB</Company>
 		<Copyright>Copyright (c) 2025 SVappsLAB</Copyright>

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/SVappsLAB.iRacingTelemetrySDK.csproj
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/SVappsLAB.iRacingTelemetrySDK.csproj
@@ -16,7 +16,7 @@
 		<None Include="..\..\LICENSE" Pack="true" PackagePath="" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
 		<PackageReference Include="YamlDotNet" Version="16.3.0" />
 		<ProjectReference Include="..\SVappsLAB.iRacingTelemetrySDK.CodeGen\SVappsLAB.iRacingTelemetrySDK.CodeGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 		<ProjectReference Include="..\SVappsLAB.iRacingTelemetrySDK.EnumsAndFlags\SVappsLAB.iRacingTelemetrySDK.EnumsAndFlags.csproj" PrivateAssets="all" />

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/YamlParser.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/YamlParser.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/SVappsLAB.iRacingTelemetrySDK/irSDK_defines.cs
+++ b/Sdk/SVappsLAB.iRacingTelemetrySDK/irSDK_defines.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,11 @@
 
 using System;
 using System.Runtime.InteropServices;
+using SVappsLAB.iRacingTelemetrySDK.DataProviders;
 
 namespace SVappsLAB.iRacingTelemetrySDK.irSDKDefines
 {
-    static internal class Constants
+    internal static class Constants
     {
         public const int IRSDK_MAX_BUFS = 4;
         public const int IRSDK_MAX_STRING = 32;

--- a/Sdk/tests/IBT_Tests/Files/ReadFile.cs
+++ b/Sdk/tests/IBT_Tests/Files/ReadFile.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/tests/IBT_Tests/Fixture.cs
+++ b/Sdk/tests/IBT_Tests/Fixture.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/tests/IBT_Tests/GlobalUsings.cs
+++ b/Sdk/tests/IBT_Tests/GlobalUsings.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/tests/IBT_Tests/IBT_Tests.csproj
+++ b/Sdk/tests/IBT_Tests/IBT_Tests.csproj
@@ -28,9 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Sdk/tests/IBT_Tests/SessionInfo/SessionInfoTests.cs
+++ b/Sdk/tests/IBT_Tests/SessionInfo/SessionInfoTests.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/tests/IBT_Tests/Variables/TelemetryVariables.cs
+++ b/Sdk/tests/IBT_Tests/Variables/TelemetryVariables.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/tests/Live_Tests/Fixture.cs
+++ b/Sdk/tests/Live_Tests/Fixture.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/tests/Live_Tests/GlobalUsings.cs
+++ b/Sdk/tests/Live_Tests/GlobalUsings.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/tests/Live_Tests/Live_Tests.csproj
+++ b/Sdk/tests/Live_Tests/Live_Tests.csproj
@@ -20,9 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Sdk/tests/Live_Tests/SessionInfoTests.cs
+++ b/Sdk/tests/Live_Tests/SessionInfoTests.cs
@@ -1,6 +1,6 @@
 
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/tests/Live_Tests/Telemetry.cs
+++ b/Sdk/tests/Live_Tests/Telemetry.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/tests/UnitTests/IBTPlaybackGovernor.cs
+++ b/Sdk/tests/UnitTests/IBTPlaybackGovernor.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Sdk/tests/UnitTests/UnitTests.csproj
+++ b/Sdk/tests/UnitTests/UnitTests.csproj
@@ -21,12 +21,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Sdk/tests/UnitTests/YamlParsing.cs
+++ b/Sdk/tests/UnitTests/YamlParsing.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright (C)2024 Scott Velez
+ * Copyright (C) 2024-2025 Scott Velez
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
refactored data access: the core logic for reading telemetry data has been moved and restructured to support different data sources. the sdk now uses modular providers, and currently supports two: Live, for connecting to a running instance of iracing, and an IBT provider for reading IBT telemetry files.